### PR TITLE
Configure EF Core with Npgsql provider

### DIFF
--- a/src/FleetOps.Api/FleetOps.Api.csproj
+++ b/src/FleetOps.Api/FleetOps.Api.csproj
@@ -1,12 +1,14 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>e09525be-41a4-4318-8c44-4eecdb71a10e</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="8.*" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.4" />
   </ItemGroup>
 

--- a/src/FleetOps.Api/FleetOps.Api.http
+++ b/src/FleetOps.Api/FleetOps.Api.http
@@ -2,7 +2,12 @@
 
 ###
 
-GET {{baseUrl}}/health
+GET {{baseUrl}}/health/ready
+Accept: application/json
+
+###
+
+GET {{baseUrl}}/health/live
 Accept: application/json
 
 ###

--- a/src/FleetOps.Api/Program.cs
+++ b/src/FleetOps.Api/Program.cs
@@ -1,15 +1,21 @@
-using System.ComponentModel;
+using FleetOps.Infrastructure;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddControllers();
+builder.Services.AddInfrastructure(builder.Configuration);
 
 // Swagger (OpenAPI)
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
 // Healthchecks
-builder.Services.AddHealthChecks();
+string? connectionString = builder.Configuration.GetConnectionString("Postgres");
+builder.Services.AddHealthChecks()
+    .AddCheck("self", () => HealthCheckResult.Healthy(), tags: new[] { "live" })
+    .AddNpgSql(connectionString!, name: "postgres", tags: new[] { "ready" });
 
 var app = builder.Build();
 
@@ -25,6 +31,13 @@ app.UseAuthorization();
 
 app.MapControllers();
 
-app.MapHealthChecks("/health");
+app.MapHealthChecks("/health/live", new HealthCheckOptions
+{
+   Predicate = r => r.Tags.Contains("live") 
+});
+app.MapHealthChecks("/health/ready", new HealthCheckOptions
+{
+   Predicate = r => r.Tags.Contains("ready") 
+});
 
 app.Run();

--- a/src/FleetOps.Api/appsettings.Development.json
+++ b/src/FleetOps.Api/appsettings.Development.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "ConnectionStrings": {
+    "Postgres": "Host=localhost;Port=5432;Database=fleetops;Username=fleetops;Password=dev_password_change_me"
   }
 }

--- a/src/FleetOps.Infrastructure/DependencyInjection.cs
+++ b/src/FleetOps.Infrastructure/DependencyInjection.cs
@@ -1,0 +1,23 @@
+using FleetOps.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FleetOps.Infrastructure;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddInfrastructure(this IServiceCollection services, IConfiguration configuration)
+    {
+        string? connectionString = configuration.GetConnectionString("Postgres");
+
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            throw new InvalidOperationException("Connection string 'Postgres' is not configured.");
+        }
+
+        services.AddDbContext<FleetOpsDbContext>(options => options.UseNpgsql(connectionString));
+
+        return services;
+    }
+}

--- a/src/FleetOps.Infrastructure/FleetOps.Infrastructure.csproj
+++ b/src/FleetOps.Infrastructure/FleetOps.Infrastructure.csproj
@@ -5,6 +5,11 @@
     <ProjectReference Include="..\FleetOps.Domain\FleetOps.Domain.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.*" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.*" />
+  </ItemGroup>
+
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/FleetOps.Infrastructure/Persistence/FleetOpsDbContext.cs
+++ b/src/FleetOps.Infrastructure/Persistence/FleetOpsDbContext.cs
@@ -1,0 +1,10 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace FleetOps.Infrastructure.Persistence;
+
+public sealed class FleetOpsDbContext : DbContext
+{
+    public FleetOpsDbContext(DbContextOptions<FleetOpsDbContext> options) : base(options)
+    {
+    }
+}


### PR DESCRIPTION
Closes #3

- Add FleetOpsDbContext and Npgsql provider
- Register Infrastructure via DI
- Add live/ready health checks with PostgreSQL readiness probe
- Update http requests for health endpoints