### PR TITLE
Refactor validations by using constants and extracting validation to extension-files

### DIFF
--- a/src/FleetOps.Application/Drivers/CreateDriver/CreateDriverCommandValidator.cs
+++ b/src/FleetOps.Application/Drivers/CreateDriver/CreateDriverCommandValidator.cs
@@ -9,7 +9,7 @@ public sealed class CreateDriverCommandValidator : AbstractValidator<CreateDrive
     {
         RuleFor(x => x.Name)
             .NotEmpty()
-            .WithMessage(ValidationConstants.MessageTemplateRequired)
+            .WithMessage(ValidationConstants.MessageTemplate.Required)
             .MaxNameLength();
     }
 }

--- a/src/FleetOps.Application/Drivers/CreateDriver/CreateDriverCommandValidator.cs
+++ b/src/FleetOps.Application/Drivers/CreateDriver/CreateDriverCommandValidator.cs
@@ -9,7 +9,7 @@ public sealed class CreateDriverCommandValidator : AbstractValidator<CreateDrive
     {
         RuleFor(x => x.Name)
             .NotEmpty()
-            .WithMessage("{PropertyName} may not be empty.")
+            .WithMessage(ValidationConstants.MessageTemplateRequired)
             .MaxNameLength();
     }
 }

--- a/src/FleetOps.Application/Validations/StringValidationExtensions.cs
+++ b/src/FleetOps.Application/Validations/StringValidationExtensions.cs
@@ -12,7 +12,7 @@ public static class StringValidationExtensions
     public static IRuleBuilderOptions<T, string> ValidRegistrationNumber<T>(this IRuleBuilder<T, string> ruleBuilder) 
         => ruleBuilder
             .NotEmpty()
-                .WithMessage("{PropertyName} may not be empty.")
+                .WithMessage(ValidationConstants.MessageTemplateRequired)
             .MaximumLength(ValidationConstants.RegistrationNumber.MaxLength)
                 .WithMessage(ValidationConstants.RegistrationNumber.MessageTemplate);
     

--- a/src/FleetOps.Application/Validations/StringValidationExtensions.cs
+++ b/src/FleetOps.Application/Validations/StringValidationExtensions.cs
@@ -12,7 +12,7 @@ public static class StringValidationExtensions
     public static IRuleBuilderOptions<T, string> ValidRegistrationNumber<T>(this IRuleBuilder<T, string> ruleBuilder) 
         => ruleBuilder
             .NotEmpty()
-                .WithMessage(ValidationConstants.MessageTemplateRequired)
+                .WithMessage(ValidationConstants.MessageTemplate.Required)
             .MaximumLength(ValidationConstants.RegistrationNumber.MaxLength)
                 .WithMessage(ValidationConstants.RegistrationNumber.MessageTemplate);
     

--- a/src/FleetOps.Application/Validations/ValidationConstants.cs
+++ b/src/FleetOps.Application/Validations/ValidationConstants.cs
@@ -2,6 +2,8 @@ namespace FleetOps.Application.Validations;
 
 public static class ValidationConstants
 {
+    public const string MessageTemplateRequired = "{PropertyName} may not be empty.";
+    
     public static class Names
     {
         public const int MaxLength = 200;

--- a/src/FleetOps.Application/Validations/ValidationConstants.cs
+++ b/src/FleetOps.Application/Validations/ValidationConstants.cs
@@ -2,8 +2,11 @@ namespace FleetOps.Application.Validations;
 
 public static class ValidationConstants
 {
-    public const string MessageTemplateRequired = "{PropertyName} may not be empty.";
-    
+    public static class MessageTemplate
+    {
+        public const string Required = "{PropertyName} may not be empty.";
+    }
+
     public static class Names
     {
         public const int MaxLength = 200;


### PR DESCRIPTION
# Refactor validations

- MessageTemplate used more than once is extracted to ValidationConstants
- Validations are extracted to extension-files