### PR TITLE
Validate assignment references existing driver and vehicle

### DIFF
--- a/src/FleetOps.Api/Controllers/VehiclesController.cs
+++ b/src/FleetOps.Api/Controllers/VehiclesController.cs
@@ -1,4 +1,3 @@
-using System.Threading.Tasks;
 using FleetOps.Api.Contracts.Vehicles;
 using FleetOps.Application.Vehicles;
 using FleetOps.Application.Vehicles.CreateVehicle;

--- a/src/FleetOps.Api/HttpRequest/Assignments/CreateAssignment.http
+++ b/src/FleetOps.Api/HttpRequest/Assignments/CreateAssignment.http
@@ -1,4 +1,6 @@
 @baseUrl = http://localhost:5144
+@validDriver = "76ccefd1-30e9-402c-a61a-18314569c789"
+@validVehicle = "119e6e44-fe0e-465e-918f-2a50ed92bed3"
 
 ###
 POST {{baseUrl}}/assignments
@@ -6,8 +8,8 @@ Content-Type: application/json
 Accept: application/json
 
 {
-  "driverId": "11111111-1111-1111-1111-111111111111",
-  "vehicleId": "22222222-2222-2222-2222-222222222222",
+  "driverId": {{validDriver}},
+  "vehicleId": {{validVehicle}},
   "startUtc": "2026-03-05T10:00:00Z",
   "endUtc": "2026-03-05T12:00:00Z"
 }
@@ -19,8 +21,8 @@ Content-Type: application/json
 Accept: application/json
 
 {
-  "driverId": "11111111-1111-1111-1111-111111111111",
-  "vehicleId": "33333333-3333-3333-3333-333333333333",
+  "driverId": {{validDriver}},
+  "vehicleId": {{validVehicle}},
   "startUtc": "2026-03-05T11:00:00Z",
   "endUtc": "2026-03-05T13:00:00Z"
 }
@@ -32,8 +34,8 @@ Content-Type: application/json
 Accept: application/json
 
 {
-  "driverId": "44444444-4444-4444-4444-444444444444",
-  "vehicleId": "55555555-5555-5555-5555-555555555555",
+  "driverId": {{validDriver}},
+  "vehicleId": {{validVehicle}},
   "startUtc": "2026-03-04T15:00:00Z",
   "endUtc": "2026-03-05T14:00:00Z"
 }

--- a/src/FleetOps.Application/Assignments/CreateAssignment/CreateAssignmentCommandValidator.cs
+++ b/src/FleetOps.Application/Assignments/CreateAssignment/CreateAssignmentCommandValidator.cs
@@ -1,5 +1,6 @@
 using FleetOps.Application.Validations;
 using FleetOps.Domain.Drivers;
+using FleetOps.Domain.Vehicles;
 using FluentValidation;
 
 namespace FleetOps.Application.Assignments.CreateAssignment;
@@ -7,10 +8,11 @@ namespace FleetOps.Application.Assignments.CreateAssignment;
 public sealed class CreateAssignmentCommandValidator : AbstractValidator<CreateAssignmentCommand>
 {
     public CreateAssignmentCommandValidator(
-        IEntityExistenceChecker<Driver, Guid> driverExistenceChecker)
+        IEntityExistenceChecker<Driver, Guid> driverExistenceChecker,
+        IEntityExistenceChecker<Vehicle, Guid> vehicleExistenceChecker)
     {
         RuleFor(x => x.DriverId).ValidateEntityExists(driverExistenceChecker, "Driver");
-        RuleFor(x => x.VehicleId).ValidRequiredId();
+        RuleFor(x => x.VehicleId).ValidateEntityExists(vehicleExistenceChecker, "Vehicle");
 
         RuleFor(x => x).ValidDateOrder(x => x.StartUtc, x => x.EndUtc);
     }

--- a/src/FleetOps.Application/Assignments/CreateAssignment/CreateAssignmentCommandValidator.cs
+++ b/src/FleetOps.Application/Assignments/CreateAssignment/CreateAssignmentCommandValidator.cs
@@ -1,13 +1,15 @@
 using FleetOps.Application.Validations;
+using FleetOps.Domain.Drivers;
 using FluentValidation;
 
 namespace FleetOps.Application.Assignments.CreateAssignment;
 
 public sealed class CreateAssignmentCommandValidator : AbstractValidator<CreateAssignmentCommand>
 {
-    public CreateAssignmentCommandValidator()
+    public CreateAssignmentCommandValidator(
+        IEntityExistenceChecker<Driver, Guid> driverExistenceChecker)
     {
-        RuleFor(x => x.DriverId).ValidRequiredId();
+        RuleFor(x => x.DriverId).ValidateEntityExists(driverExistenceChecker, "Driver");
         RuleFor(x => x.VehicleId).ValidRequiredId();
 
         RuleFor(x => x).ValidDateOrder(x => x.StartUtc, x => x.EndUtc);

--- a/src/FleetOps.Application/Assignments/CreateAssignment/CreateAssignmentHandler.cs
+++ b/src/FleetOps.Application/Assignments/CreateAssignment/CreateAssignmentHandler.cs
@@ -1,4 +1,3 @@
-using FleetOps.Application.Assignments;
 using FleetOps.Domain.Assignments;
 using FluentValidation;
 
@@ -21,12 +20,8 @@ public sealed class CreateAssignmentHandler
         CreateAssignmentCommand command, 
         CancellationToken ct)
     {
-        var validation = await _validator.ValidateAsync(command, ct);
-        if (!validation.IsValid)
-        {
-            throw new ValidationException(validation.Errors);
-        }
-
+        await _validator.ValidateAndThrowAsync(command, ct);
+        
         var assignment = new Assignment(
             command.DriverId,
             command.VehicleId,

--- a/src/FleetOps.Application/Validations/IEntityExistenceChecker.cs
+++ b/src/FleetOps.Application/Validations/IEntityExistenceChecker.cs
@@ -1,0 +1,6 @@
+namespace FleetOps.Application.Validations;
+
+public interface IEntityExistenceChecker<TEntity, TId>
+{
+    Task<bool> ExistsAsync(TId id, CancellationToken ct);
+}

--- a/src/FleetOps.Application/Validations/IdentifierValidationExtensions.cs
+++ b/src/FleetOps.Application/Validations/IdentifierValidationExtensions.cs
@@ -4,6 +4,23 @@ namespace FleetOps.Application.Validations;
 
 public static class IdentifierValidationExtensions
 {
+    public static IRuleBuilderOptions<T, Guid> ValidateEntityExists<T, TEntity>(
+        this IRuleBuilderInitial<T, Guid> ruleBuilder,
+        IEntityExistenceChecker<TEntity, Guid> existenceChecker,
+        string entityName)
+    {
+        return ruleBuilder
+            .Cascade(CascadeMode.Stop)
+            .NotEmpty()
+                .WithMessage("{PropertyName} must be specified.")
+                .WithName(entityName)
+            .MustAsync(async (id, ct) =>
+                    await existenceChecker.ExistsAsync(id, ct))
+                .WithName(entityName)
+                .WithMessage("{PropertyName} does not exist.");
+    }
+
+
     public static IRuleBuilderOptions<T, Guid> ValidRequiredId<T>(this IRuleBuilder<T, Guid> ruleBuilder)
         => ruleBuilder
             .NotEmpty()

--- a/src/FleetOps.Infrastructure/DependencyInjection.cs
+++ b/src/FleetOps.Infrastructure/DependencyInjection.cs
@@ -6,6 +6,7 @@ using FleetOps.Application.Validations;
 using FleetOps.Application.Vehicles;
 using FleetOps.Application.Vehicles.GetVehicles;
 using FleetOps.Domain.Drivers;
+using FleetOps.Domain.Vehicles;
 using FleetOps.Infrastructure.Assignments;
 using FleetOps.Infrastructure.Drivers;
 using FleetOps.Infrastructure.Persistence;
@@ -37,6 +38,7 @@ public static class DependencyInjection
 
         services.AddScoped<IVehicleRepository, VehicleRepository>();
         services.AddScoped<IVehicleQueries, VehicleQueries>();
+        services.AddScoped<IEntityExistenceChecker<Vehicle, Guid>, VehicleExistenceChecker>();
 
         return services;
     }

--- a/src/FleetOps.Infrastructure/DependencyInjection.cs
+++ b/src/FleetOps.Infrastructure/DependencyInjection.cs
@@ -2,8 +2,10 @@ using FleetOps.Application.Assignments;
 using FleetOps.Application.Assignments.GetAssignments;
 using FleetOps.Application.Drivers;
 using FleetOps.Application.Drivers.GetDrivers;
+using FleetOps.Application.Validations;
 using FleetOps.Application.Vehicles;
 using FleetOps.Application.Vehicles.GetVehicles;
+using FleetOps.Domain.Drivers;
 using FleetOps.Infrastructure.Assignments;
 using FleetOps.Infrastructure.Drivers;
 using FleetOps.Infrastructure.Persistence;
@@ -28,8 +30,11 @@ public static class DependencyInjection
         services.AddDbContext<FleetOpsDbContext>(options => options.UseNpgsql(connectionString));
         services.AddScoped<IAssignmentRepository, AssignmentRepository>();
         services.AddScoped<IAssignmentQueries, AssignmentQueries>();
+
         services.AddScoped<IDriverRepository, DriverRepository>();
         services.AddScoped<IDriverQueries, DriverQueries>();
+        services.AddScoped<IEntityExistenceChecker<Driver, Guid>, DriverExistenceChecker>();
+
         services.AddScoped<IVehicleRepository, VehicleRepository>();
         services.AddScoped<IVehicleQueries, VehicleQueries>();
 

--- a/src/FleetOps.Infrastructure/Drivers/DriverExistenceChecker.cs
+++ b/src/FleetOps.Infrastructure/Drivers/DriverExistenceChecker.cs
@@ -1,0 +1,17 @@
+using FleetOps.Application.Validations;
+using FleetOps.Domain.Drivers;
+using FleetOps.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace FleetOps.Infrastructure.Drivers;
+
+public sealed class DriverExistenceChecker : IEntityExistenceChecker<Driver, Guid>
+{
+    private readonly FleetOpsDbContext _db;
+
+    public DriverExistenceChecker(FleetOpsDbContext db) 
+        => _db = db;
+
+    public Task<bool> ExistsAsync(Guid id, CancellationToken ct) 
+        => _db.Drivers.AsNoTracking().AnyAsync(x => x.Id == id, ct);
+}

--- a/src/FleetOps.Infrastructure/Vehicles/VehicleExistenceChecker.cs
+++ b/src/FleetOps.Infrastructure/Vehicles/VehicleExistenceChecker.cs
@@ -12,5 +12,5 @@ public sealed class VehicleExistenceChecker : IEntityExistenceChecker<Vehicle, G
     public VehicleExistenceChecker(FleetOpsDbContext db) => _db = db;
 
     public Task<bool> ExistsAsync(Guid id, CancellationToken ct) 
-        => _db.Vehicles.AsNoTracking().AnyAsync(x => x.Id == id);
+        => _db.Vehicles.AsNoTracking().AnyAsync(x => x.Id == id, ct);
 }

--- a/src/FleetOps.Infrastructure/Vehicles/VehicleExistenceChecker.cs
+++ b/src/FleetOps.Infrastructure/Vehicles/VehicleExistenceChecker.cs
@@ -1,0 +1,16 @@
+using FleetOps.Application.Validations;
+using FleetOps.Domain.Vehicles;
+using FleetOps.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace FleetOps.Infrastructure.Vehicles;
+
+public sealed class VehicleExistenceChecker : IEntityExistenceChecker<Vehicle, Guid>
+{
+    private readonly FleetOpsDbContext _db;
+
+    public VehicleExistenceChecker(FleetOpsDbContext db) => _db = db;
+
+    public Task<bool> ExistsAsync(Guid id, CancellationToken ct) 
+        => _db.Vehicles.AsNoTracking().AnyAsync(x => x.Id == id);
+}


### PR DESCRIPTION
Closes #41

- Add driver and vehicle existence checks
- Validate assignment references before persistence
- Return structured validation errors for missing references