### PR TITLE
Add foreign keys from assignments to drivers and vehicles

### DIFF
--- a/src/FleetOps.Domain/Assignments/Assignment.cs
+++ b/src/FleetOps.Domain/Assignments/Assignment.cs
@@ -1,3 +1,6 @@
+using FleetOps.Domain.Drivers;
+using FleetOps.Domain.Vehicles;
+
 namespace FleetOps.Domain.Assignments;
 
 public sealed class Assignment
@@ -7,9 +10,13 @@ public sealed class Assignment
     public Guid DriverId { get; private set; }
     public Guid VehicleId { get; private set; }
 
+
     public DateTimeOffset StartUtc { get; private set; }
     public DateTimeOffset EndUtc { get; private set; }
 
+    public Driver Driver { get; private set; } = null!;
+    public Vehicle Vehicle { get; private set; } = null!;
+    
     private Assignment() {} // For ORM
 
     public Assignment(Guid driverId, Guid vehicleId, DateTimeOffset startUtc, DateTimeOffset endUtc)

--- a/src/FleetOps.Domain/Drivers/Driver.cs
+++ b/src/FleetOps.Domain/Drivers/Driver.cs
@@ -1,3 +1,5 @@
+using FleetOps.Domain.Assignments;
+
 namespace FleetOps.Domain.Drivers;
 
 public sealed class Driver
@@ -5,6 +7,7 @@ public sealed class Driver
     public Guid Id { get; private set; } = Guid.NewGuid();
     public string Name { get; private set; }
     public bool IsActive { get; private set; }
+    public ICollection<Assignment> Assignments { get; private set; } = new List<Assignment>();
 
     private Driver() // For EF Core
     {

--- a/src/FleetOps.Domain/Vehicles/Vehicle.cs
+++ b/src/FleetOps.Domain/Vehicles/Vehicle.cs
@@ -1,4 +1,4 @@
-using System.IO.Compression;
+using FleetOps.Domain.Assignments;
 
 namespace FleetOps.Domain.Vehicles;
 
@@ -7,6 +7,7 @@ public sealed class Vehicle
     public Guid Id { get; private set; } = Guid.NewGuid();
     public string RegistrationNumber { get; private set; }
     public bool IsActive { get; private set; }
+    public ICollection<Assignment> Assignments { get; private set; } = new List<Assignment>();
 
     private Vehicle()  // For EF Core
     {

--- a/src/FleetOps.Infrastructure/Persistence/FleetOpsDbContext.cs
+++ b/src/FleetOps.Infrastructure/Persistence/FleetOpsDbContext.cs
@@ -29,6 +29,16 @@ public sealed class FleetOpsDbContext : DbContext
 
            entity.Property(x => x.StartUtc).HasColumnName("start_utc").IsRequired();
            entity.Property(x => x.EndUtc).HasColumnName("end_utc").IsRequired(); 
+
+           entity.HasOne(x => x.Driver)
+               .WithMany(x => x.Assignments)
+               .HasForeignKey(x => x.DriverId)
+               .OnDelete(DeleteBehavior.Restrict);
+
+           entity.HasOne(x => x.Vehicle)
+               .WithMany(x => x.Assignments)
+               .HasForeignKey(x => x.VehicleId)
+               .OnDelete(DeleteBehavior.Restrict);
         });
 
         modelBuilder.Entity<Driver>(entity =>

--- a/src/FleetOps.Infrastructure/Persistence/Migrations/20260403101849_AddAssignmentForeignKeys.Designer.cs
+++ b/src/FleetOps.Infrastructure/Persistence/Migrations/20260403101849_AddAssignmentForeignKeys.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FleetOps.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FleetOps.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(FleetOpsDbContext))]
-    partial class FleetOpsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260403101849_AddAssignmentForeignKeys")]
+    partial class AddAssignmentForeignKeys
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/FleetOps.Infrastructure/Persistence/Migrations/20260403101849_AddAssignmentForeignKeys.cs
+++ b/src/FleetOps.Infrastructure/Persistence/Migrations/20260403101849_AddAssignmentForeignKeys.cs
@@ -1,0 +1,60 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FleetOps.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAssignmentForeignKeys : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_assignments_driver_id",
+                table: "assignments",
+                column: "driver_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_assignments_vehicle_id",
+                table: "assignments",
+                column: "vehicle_id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_assignments_drivers_driver_id",
+                table: "assignments",
+                column: "driver_id",
+                principalTable: "drivers",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_assignments_vehicles_vehicle_id",
+                table: "assignments",
+                column: "vehicle_id",
+                principalTable: "vehicles",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_assignments_drivers_driver_id",
+                table: "assignments");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_assignments_vehicles_vehicle_id",
+                table: "assignments");
+
+            migrationBuilder.DropIndex(
+                name: "IX_assignments_driver_id",
+                table: "assignments");
+
+            migrationBuilder.DropIndex(
+                name: "IX_assignments_vehicle_id",
+                table: "assignments");
+        }
+    }
+}


### PR DESCRIPTION
Closes #44

- Add navigation properties for Assignment, Driver and Vehicle
- Configure EF Core foreign key mappings
- Add migration for assignment foreign keys
- Use Restrict delete behavior to preserve assignment history