### PR TITLE
Introduce request builder for integration tests

### DIFF
--- a/tests/FleetOps.Tests.Integration/Application/Assignments/CreateAssignmentTests.cs
+++ b/tests/FleetOps.Tests.Integration/Application/Assignments/CreateAssignmentTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Json;
 using FleetOps.Tests.Integration.Infrastructure.Database;
 using FleetOps.Tests.Integration.Infrastructure.Fixtures;
+using FleetOps.Tests.Integration.Infrastructure.Scenarios;
 using Microsoft.Extensions.DependencyInjection;
 using Shouldly;
 
@@ -27,13 +28,7 @@ public sealed class CreateAssignmentTests : IClassFixture<IntegrationTestWebAppF
     {
         var vehicleId = await _dbSeeder.SeedVehicle("Vehicle1", true);
 
-        var request = new
-        {
-          driverId = Guid.NewGuid(),
-          vehicleId,
-          startUtc =  TimeTestFixtures.Period1.Start,
-          endUtc = TimeTestFixtures.Period1.End_Valid
-        };
+        var request = AssignmentRequestBuilder.WithMissingDriver(vehicleId).Build();
 
         var response = await _client.PostAsJsonAsync("/assignments", request);
 
@@ -45,13 +40,7 @@ public sealed class CreateAssignmentTests : IClassFixture<IntegrationTestWebAppF
     {
         var driverId = await _dbSeeder.SeedDriver("Driver1");
 
-        var request = new
-        {
-            driverId,
-            vehicleId = Guid.NewGuid(),
-          startUtc =  TimeTestFixtures.Period1.Start,
-          endUtc = TimeTestFixtures.Period1.End_Valid
-        };
+        var request = AssignmentRequestBuilder.WithMissingVehicle(driverId).Build();
 
         var response = await _client.PostAsJsonAsync("/assignments", request);
 
@@ -64,13 +53,10 @@ public sealed class CreateAssignmentTests : IClassFixture<IntegrationTestWebAppF
         var driverId = await _dbSeeder.SeedDriver("Driver");
         var vehicleId = await _dbSeeder.SeedVehicle("Vehicle1");
 
-        var request = new
-        {
-            driverId,
-            vehicleId,
-            startUtc = TimeTestFixtures.Period1.Start,
-            endUtc = TimeTestFixtures.Period1.End_Invalid_BeforeStart
-        };
+        var request = AssignmentRequestBuilder
+            .For(driverId, vehicleId)
+            .WithEndBeforeStart()
+            .Build();
 
         var response = await _client.PostAsJsonAsync("/assignments", request);
 
@@ -85,24 +71,11 @@ public sealed class CreateAssignmentTests : IClassFixture<IntegrationTestWebAppF
         var vehicle1Id = await _dbSeeder.SeedVehicle("Vehicle1");
         var vehicle2Id = await _dbSeeder.SeedVehicle("Vehicle2");
 
-        var assignment1 = new
-        {
-            driverId = driver1Id,
-            vehicleId = vehicle1Id,
-            startUtc =  TimeTestFixtures.Period1.Start,
-            endUtc = TimeTestFixtures.Period1.End_Valid
-        };
+        var assignment1 = AssignmentRequestBuilder.For(driver1Id, vehicle1Id).Build();
         _ = await _client.PostAsJsonAsync("/assignments", assignment1);
 
         // Act
-        var request = new
-        {
-            driverId = driver1Id,
-            vehicleId = vehicle2Id,
-            startUtc = TimeTestFixtures.Period2.Start_Invalid_ConflictWithPeriod1,
-            endUtc = TimeTestFixtures.Period2.End_Valid
-        };
-
+        var request = AssignmentRequestBuilder.For(driver1Id, vehicle2Id).OverlappingPeriod1().Build();
         var response = await _client.PostAsJsonAsync("/assignments", request);
 
         // Assert
@@ -117,24 +90,13 @@ public sealed class CreateAssignmentTests : IClassFixture<IntegrationTestWebAppF
         var driver2Id = await _dbSeeder.SeedDriver("Driver2");
         var vehicle1Id = await _dbSeeder.SeedVehicle("Vehicle1");
 
-        var assignment1 = new
-        {
-            driverId = driver1Id,
-            vehicleId = vehicle1Id,
-            startUtc = TimeTestFixtures.Period1.Start,
-            endUtc = TimeTestFixtures.Period1.End_Valid
-        };
+        var assignment1 = AssignmentRequestBuilder.For(driver1Id, vehicle1Id).Build();
 
         _ = await _client.PostAsJsonAsync("/assignments", assignment1);
 
         // Act
-        var request = new
-        {
-            driverId = driver2Id,
-            vehicleId = vehicle1Id,
-            startUtc = TimeTestFixtures.Period2.Start_Invalid_ConflictWithPeriod1,
-            endUtc = TimeTestFixtures.Period2.End_Valid
-        };
+        var request = AssignmentRequestBuilder
+            .For(driver2Id, vehicle1Id).OverlappingPeriod1().Build();
 
         var response = await _client.PostAsJsonAsync("/assignments", request);
 
@@ -151,24 +113,15 @@ public sealed class CreateAssignmentTests : IClassFixture<IntegrationTestWebAppF
         var vehicle1Id = await _dbSeeder.SeedVehicle("Vehicle1");
         var vehicle2Id = await _dbSeeder.SeedVehicle("Vehicle2");
 
-        var assignment1 = new
-        {
-            driverId = driver1Id,
-            vehicleId = vehicle1Id,
-            startUtc = TimeTestFixtures.Period1.Start,
-            endUtc = TimeTestFixtures.Period1.End_Valid
-        };
+        var assignment1 = AssignmentRequestBuilder.For(driver1Id, vehicle1Id).Build();
 
         _ = await _client.PostAsJsonAsync("/assignments", assignment1);
 
         // Act
-        var request = new
-        {
-            driverId = driver2Id,
-            vehicleId = vehicle2Id,
-            startUtc = TimeTestFixtures.Period2.Start_Invalid_ConflictWithPeriod1,
-            endUtc = TimeTestFixtures.Period2.End_Valid
-        };
+        var request = AssignmentRequestBuilder
+            .For(driver2Id, vehicle2Id)
+            .OverlappingPeriod1()
+            .Build();
 
         var response = await _client.PostAsJsonAsync("/assignments", request);
 
@@ -183,24 +136,13 @@ public sealed class CreateAssignmentTests : IClassFixture<IntegrationTestWebAppF
         var driver1Id = await _dbSeeder.SeedDriver("Driver1");
         var vehicle1Id = await _dbSeeder.SeedVehicle("Vehicle1");
 
-        var assignment1 = new
-        {
-            driverId = driver1Id,
-            vehicleId = vehicle1Id,
-            startUtc = TimeTestFixtures.Period1.Start,
-            endUtc = TimeTestFixtures.Period1.End_Valid
-        };
+        var assignment1 = AssignmentRequestBuilder.For(driver1Id, vehicle1Id).Build();
 
         _ = await _client.PostAsJsonAsync("/assignments", assignment1);
 
         // Act
-        var request = new
-        {
-            driverId = driver1Id,
-            vehicleId = vehicle1Id,
-            startUtc = TimeTestFixtures.Period2.Start_Valid_Back2BackWithPeriod1End,
-            endUtc = TimeTestFixtures.Period2.End_Valid
-        };
+        var request = AssignmentRequestBuilder
+            .For(driver1Id, vehicle1Id).BackToBackAfterPeriod1().Build();
 
         var response = await _client.PostAsJsonAsync("/assignments", request);
 
@@ -214,13 +156,7 @@ public sealed class CreateAssignmentTests : IClassFixture<IntegrationTestWebAppF
         var driverId = await _dbSeeder.SeedDriver("Driver1");
         var vehicleId = await _dbSeeder.SeedVehicle("Vehicle1");
 
-        var request = new
-        {
-            driverId,
-            vehicleId,
-            startUtc =  TimeTestFixtures.Period1.Start,
-            endUtc = TimeTestFixtures.Period1.End_Valid
-        };
+        var request = AssignmentRequestBuilder.For(driverId, vehicleId).Build();
 
         var response = await _client.PostAsJsonAsync("/assignments", request);
 

--- a/tests/FleetOps.Tests.Integration/Infrastructure/Scenarios/AssignmentRequestBuilder.cs
+++ b/tests/FleetOps.Tests.Integration/Infrastructure/Scenarios/AssignmentRequestBuilder.cs
@@ -1,0 +1,64 @@
+using FleetOps.Tests.Integration.Infrastructure.Fixtures;
+
+namespace FleetOps.Tests.Integration.Infrastructure.Scenarios;
+
+public sealed class AssignmentRequestBuilder
+{
+    private Guid _driverId;
+    private Guid _vehicleId;
+    private DateTimeOffset _startUtc = TimeTestFixtures.Period1.Start;
+    private DateTimeOffset _endUtc = TimeTestFixtures.Period1.End_Valid;
+
+    private AssignmentRequestBuilder(Guid driverId, Guid vehicleId)
+    {
+        _driverId = driverId;
+        _vehicleId = vehicleId;
+    }
+
+    public static AssignmentRequestBuilder For(Guid driverId, Guid vehicleId) 
+        => new(driverId, vehicleId);
+
+    public static AssignmentRequestBuilder WithMissingDriver(Guid vehicleId)
+        => new(Guid.NewGuid(), vehicleId);
+
+    public static AssignmentRequestBuilder WithMissingVehicle(Guid driverId)
+        => new (driverId, Guid.NewGuid());
+
+    public AssignmentRequestBuilder WithEndBeforeStart()
+    {
+        _startUtc = TimeTestFixtures.Period1.Start;
+        _endUtc = TimeTestFixtures.Period1.End_Invalid_BeforeStart;
+        return this;
+    }
+
+    public AssignmentRequestBuilder InPeriod1()
+    {
+        _startUtc = TimeTestFixtures.Period1.Start;
+        _endUtc = TimeTestFixtures.Period1.End_Valid;
+        return this;
+    }
+
+    public AssignmentRequestBuilder OverlappingPeriod1()
+    {
+        _startUtc = TimeTestFixtures.Period2.Start_Invalid_ConflictWithPeriod1;
+        _endUtc = TimeTestFixtures.Period2.End_Valid;
+        return this;
+    }
+
+    public AssignmentRequestBuilder BackToBackAfterPeriod1()
+    {
+        _startUtc = TimeTestFixtures.Period2.Start_Valid_Back2BackWithPeriod1End;
+        _endUtc = TimeTestFixtures.Period2.End_Valid;
+        return this;
+    }
+
+    public AssignmentRequestBuilder AfterPeriod1()
+    {
+        _startUtc = TimeTestFixtures.Period2.Start_Valid_AfterValidEnd;
+        _endUtc = TimeTestFixtures.Period2.End_Valid;
+        return this;
+    }
+
+    public TestCreateAssignmentRequest Build() 
+        => new(_driverId, _vehicleId, _startUtc, _endUtc);
+}

--- a/tests/FleetOps.Tests.Integration/Infrastructure/Scenarios/TestCreateAssignmentRequest.cs
+++ b/tests/FleetOps.Tests.Integration/Infrastructure/Scenarios/TestCreateAssignmentRequest.cs
@@ -1,0 +1,7 @@
+namespace FleetOps.Tests.Integration.Infrastructure.Scenarios;
+
+public sealed record TestCreateAssignmentRequest(
+    Guid DriverId,
+    Guid VehicleId,
+    DateTimeOffset StartUtc,
+    DateTimeOffset EndUtc);


### PR DESCRIPTION
Refactors assignment integration tests to use a dedicated request builder for create-assignment scenario.

- Add 'AssignmentRequestBuilder' for constructing assignment test requests
- Add 'TestCreateAssignmentRequest' as the explicit request DTO for integration tests
- Replace repeated anonymous request objects in 'CreateAssignmentTests'
- Add fluent helpers for the common scenarios

This reduces duplication in the assignment integration tests and makes each test scenario easier to read from the arrange step.