### PR TITLE
Add validation error codes to API validation error responses

### DIFF
--- a/src/FleetOps.Api/Contracts/ApiErrorCodes.cs
+++ b/src/FleetOps.Api/Contracts/ApiErrorCodes.cs
@@ -1,0 +1,7 @@
+namespace FleetOps.Api.Contracts;
+
+public static class ApiErrorCodes
+{
+    public static (string ErrorCode, string Message) ValidationError => ("validation_error", "One or more validation errors occurred.");
+    public static (string ErrorCode, string Message) ServerError => ("server_error", "An unexpected error occurred.");
+}

--- a/src/FleetOps.Api/Contracts/ErrorDetails.cs
+++ b/src/FleetOps.Api/Contracts/ErrorDetails.cs
@@ -1,0 +1,3 @@
+namespace FleetOps.Api.Contracts;
+
+public sealed record ErrorDetail(string ErrorCode, string Message);

--- a/src/FleetOps.Api/Contracts/ErrorResponse.cs
+++ b/src/FleetOps.Api/Contracts/ErrorResponse.cs
@@ -3,5 +3,5 @@ namespace FleetOps.Api.Contracts;
 public sealed record ErrorResponse(
     string Code,
     string Message,
-    Dictionary<string, string[]>? Details = null
+    Dictionary<string, ErrorDetail[]>? Details = null
 );

--- a/src/FleetOps.Api/Middleware/ExceptionHandlingMiddleware.cs
+++ b/src/FleetOps.Api/Middleware/ExceptionHandlingMiddleware.cs
@@ -39,11 +39,13 @@ public sealed class ExceptionHandlingMiddleware
         context.Response.StatusCode = StatusCodes.Status400BadRequest;
         context.Response.ContentType = "application/json";
 
-        Dictionary<string, string[]> details = ex.Errors
+        Dictionary<string, ErrorDetail[]> details = ex.Errors
             .GroupBy(x => x.PropertyName)
             .ToDictionary(
                 g => g.Key,
-                g => g.Select(x => x.ErrorMessage).ToArray());
+                g => g.Select(x => new ErrorDetail(
+                    x.ErrorCode,
+                    x.ErrorMessage)).ToArray());
 
         var response = new ErrorResponse(
             "validation_error",

--- a/src/FleetOps.Api/Middleware/ExceptionHandlingMiddleware.cs
+++ b/src/FleetOps.Api/Middleware/ExceptionHandlingMiddleware.cs
@@ -1,4 +1,6 @@
 using FleetOps.Api.Contracts;
+using FleetOps.Domain.Errors;
+using FleetOps.Domain.Exceptions;
 using FluentValidation;
 using Microsoft.EntityFrameworkCore;
 using Npgsql;
@@ -24,6 +26,10 @@ public sealed class ExceptionHandlingMiddleware
         {
             await HandleValidationException(context, ex);
         }
+        catch (DomainValidationException ex)
+        {
+            await HandleDomainValidationException(context, ex);
+        }
         catch (DbUpdateException ex) when (ex.InnerException is PostgresException pgEx)
         {
             await HandlePostgresException(context, pgEx);
@@ -32,6 +38,25 @@ public sealed class ExceptionHandlingMiddleware
         {
             await HandleUnexpectedException(context);
         }
+    }
+
+    private async Task HandleDomainValidationException(HttpContext context, DomainValidationException ex)
+    {
+        context.Response.StatusCode = StatusCodes.Status400BadRequest;
+        context.Response.ContentType = "application/json";
+
+        var response = new ErrorResponse(
+            ApiErrorCodes.ValidationError.ErrorCode,
+            ApiErrorCodes.ValidationError.Message,
+            new ()
+            {
+                { 
+                    ex.PropertyName, 
+                    [ new ErrorDetail(ex.ErrorCode, ex.Message) ] 
+                }
+            });
+
+        await context.Response.WriteAsJsonAsync(response);
     }
 
     private static async Task HandleValidationException(HttpContext context, ValidationException ex)
@@ -48,8 +73,8 @@ public sealed class ExceptionHandlingMiddleware
                     x.ErrorMessage)).ToArray());
 
         var response = new ErrorResponse(
-            "validation_error",
-            "One or more validation errors occurred.",
+            ApiErrorCodes.ValidationError.ErrorCode,
+            ApiErrorCodes.ValidationError.Message,
             details);
 
         await context.Response.WriteAsJsonAsync(response);
@@ -66,29 +91,62 @@ public sealed class ExceptionHandlingMiddleware
             case "ex_assignments_driver_no_overlap":
                 context.Response.StatusCode = StatusCodes.Status409Conflict;
                 response = new ErrorResponse(
-                    "driver_overlap",
-                    "Driver already has an assignment during this time period.");
+                    ApiErrorCodes.ValidationError.ErrorCode,
+                    ApiErrorCodes.ValidationError.Message,
+                    new ()
+                    {
+                        { "DriverId", 
+                        [new ErrorDetail(
+                            ErrorCodes.Assignment.DriverId.Overlap,
+                            "Driver already has an assignment during this time period.")] 
+                        }
+                    });
                 break;
 
             case "ex_assignments_vehicle_no_overlap":
                 context.Response.StatusCode = StatusCodes.Status409Conflict;
                 response = new ErrorResponse(
-                    "vehicle_overlap",
-                    "Vehicle already has an assignment during this time period.");
+                    ApiErrorCodes.ValidationError.ErrorCode,
+                    ApiErrorCodes.ValidationError.Message,
+                    new ()
+                    {
+                        { "VehicleId", 
+                        [new ErrorDetail(
+                            ErrorCodes.Assignment.VehicleId.Overlap,
+                            "Vehicle already has an assignment during this time period.")] 
+                        }
+                    });                
                 break;
 
             case "ck_assignments_time":
                 context.Response.StatusCode = StatusCodes.Status400BadRequest;
                 response = new ErrorResponse(
-                    "invalid_time_range",
-                    "EndUtc must be greater than StartUtc");
+                    ApiErrorCodes.ValidationError.ErrorCode,
+                    ApiErrorCodes.ValidationError.Message,
+                    new ()
+                    {
+                        { 
+                            "startUtc", [new ErrorDetail(ErrorCodes.Assignment.TimeRange.Invalid,"StartUtc must be earlier than EndUtc.")]
+                        },
+                        {
+                            "endUtc", [new ErrorDetail(ErrorCodes.Assignment.TimeRange.Invalid,"EndUtc must be later than StartUtc.")] 
+                        }
+                    });      
                 break;
 
             default:
                 context.Response.StatusCode = StatusCodes.Status500InternalServerError;
                 response = new ErrorResponse(
-                    "database_error",
-                    "An unexpected database error occurred.");
+                    ApiErrorCodes.ServerError.ErrorCode,
+                    ApiErrorCodes.ServerError.Message,
+                    new ()
+                    {
+                        { ApiErrorCodes.ServerError.ErrorCode, 
+                        [new ErrorDetail(
+                            ApiErrorCodes.ServerError.ErrorCode,
+                            ApiErrorCodes.ServerError.Message)] 
+                        }
+                    }); 
                 break;
         }
 
@@ -101,8 +159,16 @@ public sealed class ExceptionHandlingMiddleware
         context.Response.ContentType = "application/json";
 
         var response = new ErrorResponse(
-            "internal_server_error",
-            "An unexpected error occurred.");
+            ApiErrorCodes.ServerError.ErrorCode,
+            ApiErrorCodes.ServerError.Message,
+            new ()
+            {
+                { ApiErrorCodes.ServerError.ErrorCode, 
+                [new ErrorDetail(
+                    ApiErrorCodes.ServerError.ErrorCode,
+                    ApiErrorCodes.ServerError.Message)] 
+                }
+            }); 
 
         await context.Response.WriteAsJsonAsync(response);
     }

--- a/src/FleetOps.Application/Assignments/CreateAssignment/CreateAssignmentCommandValidator.cs
+++ b/src/FleetOps.Application/Assignments/CreateAssignment/CreateAssignmentCommandValidator.cs
@@ -1,5 +1,6 @@
 using FleetOps.Application.Validations;
 using FleetOps.Domain.Drivers;
+using FleetOps.Domain.Errors;
 using FleetOps.Domain.Vehicles;
 using FluentValidation;
 
@@ -14,17 +15,17 @@ public sealed class CreateAssignmentCommandValidator : AbstractValidator<CreateA
         RuleFor(x => x.DriverId).ValidateEntityExists(
             driverExistenceChecker,
             "Driver",
-            ValidationErrorCodes.Assignment.DriverId.Required,
-            ValidationErrorCodes.Assignment.DriverId.NotFound);
+            ErrorCodes.Assignment.DriverId.Required,
+            ErrorCodes.Assignment.DriverId.NotFound);
 
         RuleFor(x => x.VehicleId).ValidateEntityExists(
             vehicleExistenceChecker,
             "Vehicle",
-            ValidationErrorCodes.Assignment.VehicleId.Required,
-            ValidationErrorCodes.Assignment.VehicleId.NotFound);
+            ErrorCodes.Assignment.VehicleId.Required,
+            ErrorCodes.Assignment.VehicleId.NotFound);
 
         RuleFor(x => x)
             .ValidDateOrder(x => x.StartUtc, x => x.EndUtc,
-                ValidationErrorCodes.Assignment.TimeRange.Invalid);
+                ErrorCodes.Assignment.TimeRange.Invalid);
     }
 }

--- a/src/FleetOps.Application/Assignments/GetAssignments/GetAssignmentsQueryValidator.cs
+++ b/src/FleetOps.Application/Assignments/GetAssignments/GetAssignmentsQueryValidator.cs
@@ -1,4 +1,5 @@
 using FleetOps.Application.Validations;
+using FleetOps.Domain.Errors;
 using FluentValidation;
 
 namespace FleetOps.Application.Assignments.GetAssignments;
@@ -12,6 +13,6 @@ public sealed class GetAssignmentsQueryValidator : AbstractValidator<GetAssignme
         RuleFor(x => x.Offset).ValidOffset();
 
         RuleFor(x => x).ValidDateOrder(x => x.FromUtc, x => x.ToUtc,
-            ValidationErrorCodes.Assignment.TimeRange.Invalid);
+            ErrorCodes.Assignment.TimeRange.Invalid);
     }
 }

--- a/src/FleetOps.Application/Drivers/CreateDriver/CreateDriverCommandValidator.cs
+++ b/src/FleetOps.Application/Drivers/CreateDriver/CreateDriverCommandValidator.cs
@@ -1,4 +1,5 @@
 using FleetOps.Application.Validations;
+using FleetOps.Domain.Errors;
 using FluentValidation;
 
 namespace FleetOps.Application.Drivers.CreateDriver;
@@ -9,8 +10,8 @@ public sealed class CreateDriverCommandValidator : AbstractValidator<CreateDrive
     {
         RuleFor(x => x.Name)
             .NotEmpty()
-            .WithErrorCode(ValidationErrorCodes.Driver.Name.Required)
+            .WithErrorCode(ErrorCodes.Driver.Name.Required)
             .WithMessage(ValidationConstants.MessageTemplate.Required)
-            .MaxNameLength(ValidationErrorCodes.Driver.Name.MaxLengthExceeded);
+            .MaxNameLength(ErrorCodes.Driver.Name.MaxLengthExceeded);
     }
 }

--- a/src/FleetOps.Application/Drivers/GetDrivers/GetDriversQueryValidator.cs
+++ b/src/FleetOps.Application/Drivers/GetDrivers/GetDriversQueryValidator.cs
@@ -1,4 +1,5 @@
 using FleetOps.Application.Validations;
+using FleetOps.Domain.Errors;
 using FluentValidation;
 
 namespace FleetOps.Application.Drivers.GetDrivers;
@@ -12,7 +13,7 @@ public sealed class GetDriversQueryValidator : AbstractValidator<GetDriversQuery
         RuleFor(x => x.Offset).ValidOffset();
 
         RuleFor(x => x.Name)
-            .MaxNameLength(ValidationErrorCodes.Driver.Name.MaxLengthExceeded)
+            .MaxNameLength(ErrorCodes.Driver.Name.MaxLengthExceeded)
             .When(x => !string.IsNullOrWhiteSpace(x.Name));
     }
 }

--- a/src/FleetOps.Application/Validations/IdentifierValidationExtensions.cs
+++ b/src/FleetOps.Application/Validations/IdentifierValidationExtensions.cs
@@ -23,9 +23,4 @@ public static class IdentifierValidationExtensions
                 .WithMessage("{PropertyName} does not exist.")
                 .WithErrorCode(notfoundErrorCode);
     }
-
-    public static IRuleBuilderOptions<T, Guid> ValidRequiredId<T>(this IRuleBuilder<T, Guid> ruleBuilder)
-        => ruleBuilder
-            .NotEmpty()
-            .WithMessage("{PropertyName} must not be a non-empty GUID.");
 }

--- a/src/FleetOps.Application/Validations/PaginationValidationExtensions.cs
+++ b/src/FleetOps.Application/Validations/PaginationValidationExtensions.cs
@@ -1,3 +1,4 @@
+using FleetOps.Domain.Errors;
 using FluentValidation;
 
 namespace FleetOps.Application.Validations;
@@ -8,11 +9,11 @@ public static class PaginationValidationExtensions
         => ruleBuilder
             .InclusiveBetween(ValidationConstants.Pagination.MinPageSize, ValidationConstants.Pagination.MaxPageSize)
             .WithMessage("{PropertyName} must be between {From} and {To}.")
-            .WithErrorCode(ValidationErrorCodes.Pagination.Limit.Invalid);
+            .WithErrorCode(ErrorCodes.Pagination.Limit.Invalid);
 
     public static IRuleBuilderOptions<T, int> ValidOffset<T>(this IRuleBuilder<T, int> ruleBuilder) 
         => ruleBuilder
             .GreaterThanOrEqualTo(0)
             .WithMessage("{PropertyName} must be greater than or equal to {ComparisonValue}.")
-            .WithErrorCode(ValidationErrorCodes.Pagination.Offset.Invalid);
+            .WithErrorCode(ErrorCodes.Pagination.Offset.Invalid);
 }

--- a/src/FleetOps.Application/Validations/StringValidationExtensions.cs
+++ b/src/FleetOps.Application/Validations/StringValidationExtensions.cs
@@ -1,3 +1,4 @@
+using FleetOps.Domain.Errors;
 using FluentValidation;
 
 namespace FleetOps.Application.Validations;
@@ -17,15 +18,15 @@ public static class StringValidationExtensions
         => ruleBuilder
             .NotEmpty()
                 .WithMessage(ValidationConstants.MessageTemplate.Required)
-                .WithErrorCode(ValidationErrorCodes.Vehicle.RegistrationNumber.Required)
+                .WithErrorCode(ErrorCodes.Vehicle.RegistrationNumber.Required)
             .MaximumLength(ValidationConstants.RegistrationNumber.MaxLength)
                 .WithMessage(ValidationConstants.RegistrationNumber.MessageTemplate)
-                .WithErrorCode(ValidationErrorCodes.Vehicle.RegistrationNumber.MaxLengthExceeded);
+                .WithErrorCode(ErrorCodes.Vehicle.RegistrationNumber.MaxLengthExceeded);
     
     public static IRuleBuilderOptions<T, string?> ValidRegistrationNumberOptional<T>(this IRuleBuilder<T, string?> ruleBuilder)
         => ruleBuilder
             .MaximumLength(ValidationConstants.RegistrationNumber.MaxLength)
                 .WithMessage(ValidationConstants.RegistrationNumber.MessageTemplate)
-                .WithErrorCode(ValidationErrorCodes.Vehicle.RegistrationNumber.MaxLengthExceeded);
+                .WithErrorCode(ErrorCodes.Vehicle.RegistrationNumber.MaxLengthExceeded);
 
 }

--- a/src/FleetOps.Domain/Assignments/Assignment.cs
+++ b/src/FleetOps.Domain/Assignments/Assignment.cs
@@ -1,4 +1,6 @@
 using FleetOps.Domain.Drivers;
+using FleetOps.Domain.Errors;
+using FleetOps.Domain.Exceptions;
 using FleetOps.Domain.Vehicles;
 
 namespace FleetOps.Domain.Assignments;
@@ -21,9 +23,12 @@ public sealed class Assignment
 
     public Assignment(Guid driverId, Guid vehicleId, DateTimeOffset startUtc, DateTimeOffset endUtc)
     {
-        if (driverId == Guid.Empty) throw new ArgumentException("DriverId must be set.", nameof(driverId));
-        if (vehicleId == Guid.Empty) throw new ArgumentException("VehicleId must be set.", nameof(vehicleId));
-        if (endUtc <= startUtc) throw new ArgumentException("EndUtc must be greater than StartUtc.", nameof(endUtc));
+        if (driverId == Guid.Empty) 
+            throw new DomainValidationException(nameof(driverId), ErrorCodes.Assignment.DriverId.Required, "DriverId must be set.");
+        if (vehicleId == Guid.Empty) 
+            throw new DomainValidationException(nameof(vehicleId), ErrorCodes.Assignment.VehicleId.Required, "VehicleId must be set.");
+        if (endUtc <= startUtc) 
+            throw new DomainValidationException(nameof(endUtc), ErrorCodes.Assignment.TimeRange.Invalid, "EndUtc must be greater than StartUtc.");
 
         DriverId = driverId;
         VehicleId = vehicleId;

--- a/src/FleetOps.Domain/Drivers/Driver.cs
+++ b/src/FleetOps.Domain/Drivers/Driver.cs
@@ -1,4 +1,6 @@
 using FleetOps.Domain.Assignments;
+using FleetOps.Domain.Errors;
+using FleetOps.Domain.Exceptions;
 
 namespace FleetOps.Domain.Drivers;
 
@@ -18,7 +20,7 @@ public sealed class Driver
     {
         if (string.IsNullOrWhiteSpace(name))
         {
-            throw new ArgumentException("Name must be provided.", nameof(name));
+            throw new DomainValidationException(nameof(name), ErrorCodes.Driver.Name.Required, "Name must be provided.");
         }
 
         Name = name.Trim();

--- a/src/FleetOps.Domain/Errors/ErrorCodes.cs
+++ b/src/FleetOps.Domain/Errors/ErrorCodes.cs
@@ -1,6 +1,6 @@
-namespace FleetOps.Application.Validations;
+namespace FleetOps.Domain.Errors;
 
-public static class ValidationErrorCodes
+public static class ErrorCodes
 {
     public static class Assignment
     {
@@ -8,12 +8,14 @@ public static class ValidationErrorCodes
         {
             public const string Required = "Assignment.DriverId.Required";
             public const string NotFound = "Assignment.DriverId.NotFound";
+            public const string Overlap = "Assignment.DriverId.Overlap";
         }
 
         public static class VehicleId
         {
             public const string Required = "Assignment.VehicleId.Required";
             public const string NotFound = "Assignment.VehicleId.NotFound";
+            public const string Overlap = "Assignment.VehicleId.Overlap";
         }
 
         public static class TimeRange

--- a/src/FleetOps.Domain/Exceptions/DomainValidationException.cs
+++ b/src/FleetOps.Domain/Exceptions/DomainValidationException.cs
@@ -1,0 +1,17 @@
+namespace FleetOps.Domain.Exceptions;
+
+public sealed class DomainValidationException : Exception
+{
+    public string PropertyName { get; }
+    public string ErrorCode { get; }
+
+    public DomainValidationException(
+        string propertyName,
+        string errorCode,
+        string message)
+        : base(message)
+    {
+        PropertyName = propertyName;
+        ErrorCode = errorCode;
+    }
+}

--- a/src/FleetOps.Domain/Vehicles/Vehicle.cs
+++ b/src/FleetOps.Domain/Vehicles/Vehicle.cs
@@ -1,4 +1,6 @@
 using FleetOps.Domain.Assignments;
+using FleetOps.Domain.Errors;
+using FleetOps.Domain.Exceptions;
 
 namespace FleetOps.Domain.Vehicles;
 
@@ -18,7 +20,7 @@ public sealed class Vehicle
     {
         if (string.IsNullOrWhiteSpace(registrationnumber))
         {
-            throw new ArgumentException("RegistrationNumber must be provided.", nameof(registrationnumber));
+            throw new DomainValidationException(nameof(registrationnumber), ErrorCodes.Vehicle.RegistrationNumber.Required, "RegistrationNumber must be provided.");
         }
 
         RegistrationNumber = registrationnumber.Trim().ToUpperInvariant();

--- a/tests/FleetOps.Tests.Unit/Application/Assignments/CreateAssignmentCommandValidatorTests.cs
+++ b/tests/FleetOps.Tests.Unit/Application/Assignments/CreateAssignmentCommandValidatorTests.cs
@@ -1,7 +1,7 @@
-using System.Threading.Tasks;
 using FleetOps.Application.Assignments.CreateAssignment;
 using FleetOps.Application.Validations;
 using FleetOps.Domain.Drivers;
+using FleetOps.Domain.Errors;
 using FleetOps.Domain.Vehicles;
 using FluentValidation.TestHelper;
 using Moq;
@@ -42,7 +42,7 @@ public sealed class CreateAssignmentCommandValidatorTests
         var result = await _validator.TestValidateAsync(command);
 
         result.ShouldHaveValidationErrorFor(x => x.DriverId)
-            .WithErrorCode(ValidationErrorCodes.Assignment.DriverId.Required);
+            .WithErrorCode(ErrorCodes.Assignment.DriverId.Required);
     }       
 
     [Fact]
@@ -69,7 +69,7 @@ public sealed class CreateAssignmentCommandValidatorTests
         var result = await _validator.TestValidateAsync(command);
 
         result.ShouldHaveValidationErrorFor(x => x.VehicleId)
-            .WithErrorCode(ValidationErrorCodes.Assignment.VehicleId.Required);
+            .WithErrorCode(ErrorCodes.Assignment.VehicleId.Required);
     }
 
     [Fact]
@@ -95,7 +95,7 @@ public sealed class CreateAssignmentCommandValidatorTests
         var result = await _validator.TestValidateAsync(command);
 
         result.ShouldHaveValidationErrorFor(x => x.DriverId)
-            .WithErrorCode(ValidationErrorCodes.Assignment.DriverId.NotFound);
+            .WithErrorCode(ErrorCodes.Assignment.DriverId.NotFound);
     }             
 
     [Fact]
@@ -121,7 +121,7 @@ public sealed class CreateAssignmentCommandValidatorTests
         var result = await _validator.TestValidateAsync(command);
 
         result.ShouldHaveValidationErrorFor(x => x.VehicleId)
-            .WithErrorCode(ValidationErrorCodes.Assignment.VehicleId.NotFound);
+            .WithErrorCode(ErrorCodes.Assignment.VehicleId.NotFound);
     }
 
     [Fact]
@@ -147,9 +147,9 @@ public sealed class CreateAssignmentCommandValidatorTests
         var result = await _validator.TestValidateAsync(command);
 
         result.ShouldHaveValidationErrorFor(x => x.StartUtc)
-            .WithErrorCode(ValidationErrorCodes.Assignment.TimeRange.Invalid);
+            .WithErrorCode(ErrorCodes.Assignment.TimeRange.Invalid);
         result.ShouldHaveValidationErrorFor(x => x.EndUtc)
-            .WithErrorCode(ValidationErrorCodes.Assignment.TimeRange.Invalid);
+            .WithErrorCode(ErrorCodes.Assignment.TimeRange.Invalid);
     }
 
     [Fact]

--- a/tests/FleetOps.Tests.Unit/Application/Assignments/GetAssignmentsQueryValidatorTests.cs
+++ b/tests/FleetOps.Tests.Unit/Application/Assignments/GetAssignmentsQueryValidatorTests.cs
@@ -1,6 +1,5 @@
-using System.Threading.Tasks;
 using FleetOps.Application.Assignments.GetAssignments;
-using FleetOps.Application.Validations;
+using FleetOps.Domain.Errors;
 using FleetOps.Tests.Unit.Application.Common.Validation;
 using FluentValidation.TestHelper;
 
@@ -26,9 +25,9 @@ public sealed class GetAssignmentsQueryValidatorTests()
         var result = await _validator.TestValidateAsync(query);
 
         result.ShouldHaveValidationErrorFor(x => x.FromUtc)
-            .WithErrorCode(ValidationErrorCodes.Assignment.TimeRange.Invalid);
+            .WithErrorCode(ErrorCodes.Assignment.TimeRange.Invalid);
         result.ShouldHaveValidationErrorFor(x => x.ToUtc)
-            .WithErrorCode(ValidationErrorCodes.Assignment.TimeRange.Invalid);
+            .WithErrorCode(ErrorCodes.Assignment.TimeRange.Invalid);
     }
 
     [Fact]
@@ -45,7 +44,7 @@ public sealed class GetAssignmentsQueryValidatorTests()
     {
         var query = new GetAssignmentsQuery(null, null, null, null, 1000, 0);
 
-        await ValidationAssert.HasError(_validator, query, x => x.Limit, ValidationErrorCodes.Pagination.Limit.Invalid);
+        await ValidationAssert.HasError(_validator, query, x => x.Limit, ErrorCodes.Pagination.Limit.Invalid);
     }
 
     [Fact]
@@ -53,6 +52,6 @@ public sealed class GetAssignmentsQueryValidatorTests()
     {
         var query = new GetAssignmentsQuery(null, null, null, null, 50, -1);
 
-        await ValidationAssert.HasError(_validator, query, x => x.Offset, ValidationErrorCodes.Pagination.Offset.Invalid);
+        await ValidationAssert.HasError(_validator, query, x => x.Offset, ErrorCodes.Pagination.Offset.Invalid);
     }
 }

--- a/tests/FleetOps.Tests.Unit/Application/Common/Validation/PaginationValidationTests.cs
+++ b/tests/FleetOps.Tests.Unit/Application/Common/Validation/PaginationValidationTests.cs
@@ -1,7 +1,7 @@
 using FluentValidation;
 using FluentValidation.TestHelper;
 using FleetOps.Application.Validations;
-using System.Threading.Tasks;
+using FleetOps.Domain.Errors;
 
 namespace FleetOps.Tests.Unit.Application.Common.Validation;
 
@@ -27,7 +27,7 @@ public sealed class PaginationValidationTests
         var result = await _validator.TestValidateAsync(model);
 
         result.ShouldHaveValidationErrorFor(x => x.Limit)
-            .WithErrorCode(ValidationErrorCodes.Pagination.Limit.Invalid);
+            .WithErrorCode(ErrorCodes.Pagination.Limit.Invalid);
     }
 
     [Fact]
@@ -38,7 +38,7 @@ public sealed class PaginationValidationTests
         var result = await _validator.TestValidateAsync(model);
 
         result.ShouldHaveValidationErrorFor(x => x.Limit)
-            .WithErrorCode(ValidationErrorCodes.Pagination.Limit.Invalid);
+            .WithErrorCode(ErrorCodes.Pagination.Limit.Invalid);
     }
 
     [Fact]
@@ -69,7 +69,7 @@ public sealed class PaginationValidationTests
         var result = await _validator.TestValidateAsync(model);
 
         result.ShouldHaveValidationErrorFor(x => x.Offset)
-            .WithErrorCode(ValidationErrorCodes.Pagination.Offset.Invalid);
+            .WithErrorCode(ErrorCodes.Pagination.Offset.Invalid);
     }
 
     [Fact]

--- a/tests/FleetOps.Tests.Unit/Application/Drivers/CreateDriverCommandValidatorTests.cs
+++ b/tests/FleetOps.Tests.Unit/Application/Drivers/CreateDriverCommandValidatorTests.cs
@@ -1,5 +1,6 @@
 using FleetOps.Application.Drivers.CreateDriver;
 using FleetOps.Application.Validations;
+using FleetOps.Domain.Errors;
 using FluentValidation.TestHelper;
 
 namespace FleetOps.Tests.Unit.Application.Drivers;
@@ -16,7 +17,7 @@ public sealed class CreateDriverCommandValidationTests
         var result = await _validator.TestValidateAsync(command);
 
         result.ShouldHaveValidationErrorFor(x => x.Name)
-            .WithErrorCode(ValidationErrorCodes.Driver.Name.Required);
+            .WithErrorCode(ErrorCodes.Driver.Name.Required);
     }
 
     [Fact]
@@ -27,7 +28,7 @@ public sealed class CreateDriverCommandValidationTests
         var result = await _validator.TestValidateAsync(command);
 
         result.ShouldHaveValidationErrorFor(x => x.Name)
-            .WithErrorCode(ValidationErrorCodes.Driver.Name.MaxLengthExceeded);
+            .WithErrorCode(ErrorCodes.Driver.Name.MaxLengthExceeded);
     }
 
     [Fact]

--- a/tests/FleetOps.Tests.Unit/Application/Drivers/GetDriversQueryValidatorTests.cs
+++ b/tests/FleetOps.Tests.Unit/Application/Drivers/GetDriversQueryValidatorTests.cs
@@ -1,5 +1,5 @@
 using FleetOps.Application.Drivers.GetDrivers;
-using FleetOps.Application.Validations;
+using FleetOps.Domain.Errors;
 using FleetOps.Tests.Unit.Application.Common.Validation;
 using FluentValidation.TestHelper;
 
@@ -20,7 +20,7 @@ public sealed class GetDriversQueryValidatorTests
         var result = await _validator.TestValidateAsync(query);
 
         result.ShouldHaveValidationErrorFor(x => x.Name)
-            .WithErrorCode(ValidationErrorCodes.Driver.Name.MaxLengthExceeded);
+            .WithErrorCode(ErrorCodes.Driver.Name.MaxLengthExceeded);
     }
 
     [Fact]
@@ -47,7 +47,7 @@ public sealed class GetDriversQueryValidatorTests
     {
         var query = new GetDriversQuery(null, null, 1000, 0);
 
-        await ValidationAssert.HasError(_validator, query, x => x.Limit, ValidationErrorCodes.Pagination.Limit.Invalid);
+        await ValidationAssert.HasError(_validator, query, x => x.Limit, ErrorCodes.Pagination.Limit.Invalid);
     }
 
     [Fact]
@@ -55,7 +55,7 @@ public sealed class GetDriversQueryValidatorTests
     {
         var query = new GetDriversQuery(null, null, 50, -1);
 
-        await ValidationAssert.HasError(_validator, query, x => x.Offset, ValidationErrorCodes.Pagination.Offset.Invalid);
+        await ValidationAssert.HasError(_validator, query, x => x.Offset, ErrorCodes.Pagination.Offset.Invalid);
     }
 
 }

--- a/tests/FleetOps.Tests.Unit/Application/Vehicles/CreateVehicleCommandValidatorTests.cs
+++ b/tests/FleetOps.Tests.Unit/Application/Vehicles/CreateVehicleCommandValidatorTests.cs
@@ -1,6 +1,6 @@
-using System.Threading.Tasks;
 using FleetOps.Application.Validations;
 using FleetOps.Application.Vehicles.CreateVehicle;
+using FleetOps.Domain.Errors;
 using FluentValidation.TestHelper;
 
 namespace FleetOps.Tests.Unit.Application.Vehicles;
@@ -17,7 +17,7 @@ public sealed class CreateVehicleCommandValidatorTests
         var result = await _validator.TestValidateAsync(command);
 
         result.ShouldHaveValidationErrorFor(x => x.RegistrationNumber)
-            .WithErrorCode(ValidationErrorCodes.Vehicle.RegistrationNumber.MaxLengthExceeded);
+            .WithErrorCode(ErrorCodes.Vehicle.RegistrationNumber.MaxLengthExceeded);
     }
 
     [Fact]
@@ -28,7 +28,7 @@ public sealed class CreateVehicleCommandValidatorTests
         var result = await _validator.TestValidateAsync(command);
 
         result.ShouldHaveValidationErrorFor(x => x.RegistrationNumber)
-            .WithErrorCode(ValidationErrorCodes.Vehicle.RegistrationNumber.Required);
+            .WithErrorCode(ErrorCodes.Vehicle.RegistrationNumber.Required);
     }
 
     [Fact]

--- a/tests/FleetOps.Tests.Unit/Application/Vehicles/GetVehiclesQueryValidatorTests.cs
+++ b/tests/FleetOps.Tests.Unit/Application/Vehicles/GetVehiclesQueryValidatorTests.cs
@@ -1,5 +1,5 @@
-using FleetOps.Application.Validations;
 using FleetOps.Application.Vehicles.GetVehicles;
+using FleetOps.Domain.Errors;
 using FleetOps.Tests.Unit.Application.Common.Validation;
 using FluentValidation.TestHelper;
 
@@ -17,7 +17,7 @@ public sealed class GetVehiclesQueryValidatorTests
         var result = await _validator.TestValidateAsync(query);
 
         result.ShouldHaveValidationErrorFor(x => x.RegistrationNumber)
-            .WithErrorCode(ValidationErrorCodes.Vehicle.RegistrationNumber.MaxLengthExceeded);
+            .WithErrorCode(ErrorCodes.Vehicle.RegistrationNumber.MaxLengthExceeded);
     }
 
     [Fact]
@@ -44,7 +44,7 @@ public sealed class GetVehiclesQueryValidatorTests
     {
         var query = new GetVehiclesQuery(null, null, 1000, 0);
 
-        await ValidationAssert.HasError(_validator, query, x => x.Limit, ValidationErrorCodes.Pagination.Limit.Invalid);
+        await ValidationAssert.HasError(_validator, query, x => x.Limit, ErrorCodes.Pagination.Limit.Invalid);
     }
 
     [Fact]
@@ -52,6 +52,6 @@ public sealed class GetVehiclesQueryValidatorTests
     {
         var query = new GetVehiclesQuery(null, null, 50, -1);
 
-        await ValidationAssert.HasError(_validator, query, x => x.Offset, ValidationErrorCodes.Pagination.Offset.Invalid);
+        await ValidationAssert.HasError(_validator, query, x => x.Offset, ErrorCodes.Pagination.Offset.Invalid);
     }
 }


### PR DESCRIPTION
Closes #51 

Adds validation error codes to API validation error responses.

Validation errors now return structured error details containing both:
- 'code'
- 'message'

This allows clients to handle validation failures using stable error codes instad of relying only on human-readable messages.

## Changes
- Added structured 'ErrorDetail' API contract
- Updated 'ErrorResponse.Details' to use 'ErrorDetails'
- Updated 'ExceptionHandlingMiddleware' to serialize FluentValidation 'ErrorCode'
- Removed unused 'ValidRequiredId' helper without error-code support